### PR TITLE
Enhance planet filters and add analytics endpoints

### DIFF
--- a/app/schemas/planet.py
+++ b/app/schemas/planet.py
@@ -162,3 +162,45 @@ class DeletedPlanetOut(BaseModel):
     id: int
     name: str
     deleted_at: Optional[datetime] = Field(None, description="Deletion timestamp (UTC) or null")
+
+
+class MetricSummary(BaseModel):
+    """Minimum, maximum and average summary for a numeric metric."""
+
+    min: Optional[float] = Field(None, description="Minimum value or null when unavailable")
+    max: Optional[float] = Field(None, description="Maximum value or null when unavailable")
+    avg: Optional[float] = Field(None, description="Average value or null when unavailable")
+
+
+class PlanetStats(BaseModel):
+    """Aggregated statistics for planet metrics."""
+
+    count: int = Field(..., ge=0, description="Number of matching planets")
+    orbperd: MetricSummary
+    rade: MetricSummary
+    masse: MetricSummary
+    st_teff: MetricSummary
+    st_rad: MetricSummary
+    st_mass: MetricSummary
+
+
+class PlanetMethodStats(PlanetStats):
+    """Statistics scoped to a specific discovery method."""
+
+    disc_method: str = Field(..., description="Discovery method these statistics describe")
+
+
+class PlanetTimelinePoint(BaseModel):
+    """Discovery count for a given year."""
+
+    disc_year: int = Field(..., ge=0, description="Discovery year")
+    count: int = Field(..., ge=0, description="Number of planets discovered in that year")
+
+
+class PlanetListResponse(BaseModel):
+    """Paged planet response with pagination metadata."""
+
+    items: list[PlanetOut]
+    limit: int = Field(..., ge=1, description="Requested page size")
+    offset: int = Field(..., ge=0, description="Requested offset")
+    total: int = Field(..., ge=0, description="Total number of records that match the filters")


### PR DESCRIPTION
## Summary
- add advanced query options and pagination metadata to the `/planets` listing
- expose new `/planets/stats`, `/planets/timeline`, and `/planets/method/{disc_method}/stats` analytics endpoints
- provide JSON data for discovery visualisations alongside new response schemas

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceb5de53d0832a9bc8d97a4167a498