### PR TITLE
Add React frontend for exoplanet API

### DIFF
--- a/app/schemas/planet.py
+++ b/app/schemas/planet.py
@@ -162,3 +162,45 @@ class DeletedPlanetOut(BaseModel):
     id: int
     name: str
     deleted_at: Optional[datetime] = Field(None, description="Deletion timestamp (UTC) or null")
+
+
+class MetricSummary(BaseModel):
+    """Minimum, maximum and average summary for a numeric metric."""
+
+    min: Optional[float] = Field(None, description="Minimum value or null when unavailable")
+    max: Optional[float] = Field(None, description="Maximum value or null when unavailable")
+    avg: Optional[float] = Field(None, description="Average value or null when unavailable")
+
+
+class PlanetStats(BaseModel):
+    """Aggregated statistics for planet metrics."""
+
+    count: int = Field(..., ge=0, description="Number of matching planets")
+    orbperd: MetricSummary
+    rade: MetricSummary
+    masse: MetricSummary
+    st_teff: MetricSummary
+    st_rad: MetricSummary
+    st_mass: MetricSummary
+
+
+class PlanetMethodStats(PlanetStats):
+    """Statistics scoped to a specific discovery method."""
+
+    disc_method: str = Field(..., description="Discovery method these statistics describe")
+
+
+class PlanetTimelinePoint(BaseModel):
+    """Discovery count for a given year."""
+
+    disc_year: int = Field(..., ge=0, description="Discovery year")
+    count: int = Field(..., ge=0, description="Number of planets discovered in that year")
+
+
+class PlanetListResponse(BaseModel):
+    """Paged planet response with pagination metadata."""
+
+    items: list[PlanetOut]
+    limit: int = Field(..., ge=1, description="Requested page size")
+    offset: int = Field(..., ge=0, description="Requested offset")
+    total: int = Field(..., ge=0, description="Total number of records that match the filters")

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,42 @@
+# Exoplanet Explorer Frontend
+
+This Vite + React client consumes the Exoplanet FastAPI backend and exposes three primary views:
+
+- **Dashboard** – highlights catalog metrics and renders the annual discoveries timeline.
+- **Catalog** – interactive table with search, discovery method and year filters, plus client-side pagination.
+- **Visualizations** – charts for stellar temperature histogram, yearly discoveries and method distribution.
+
+## Getting started
+
+Install dependencies with your preferred package manager (examples below use **pnpm**, but `npm` or `yarn` also work).
+
+```bash
+pnpm install
+pnpm dev
+```
+
+The app expects the API to be available at `http://localhost:8000` during development. Override the base URL by creating a `.env` file in the `frontend` directory:
+
+```bash
+VITE_API_BASE_URL=https://your-api.example.com
+```
+
+## Project structure
+
+```
+frontend/
+  src/
+    api/           # HTTP client helpers
+    components/    # Reusable UI building blocks
+    hooks/         # Data fetching hooks powered by React Query
+    pages/         # Route-level views
+```
+
+## Production build
+
+```bash
+pnpm build
+pnpm preview
+```
+
+Deploy the contents of the generated `dist/` directory to any static hosting provider.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Exoplanet Explorer</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "exoplanet-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext ts,tsx"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.24.7",
+    "chart.js": "^4.4.0",
+    "clsx": "^2.1.0",
+    "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.20.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.0",
+    "eslint": "^8.54.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.4",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <radialGradient id="planet" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="70%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </radialGradient>
+  </defs>
+  <circle cx="50" cy="50" r="40" fill="url(#planet)" />
+  <ellipse cx="50" cy="50" rx="60" ry="18" fill="none" stroke="#f1f5f9" stroke-width="4" />
+</svg>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,19 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8000';
+
+export const buildUrl = (path: string, params?: Record<string, string | number | undefined>) => {
+  const url = new URL(path, API_BASE_URL);
+  if (params) {
+    Object.entries(params)
+      .filter(([, value]) => value !== undefined && value !== '')
+      .forEach(([key, value]) => url.searchParams.set(key, String(value)));
+  }
+  return url.toString();
+};
+
+export const get = async <T>(path: string, params?: Record<string, string | number | undefined>): Promise<T> => {
+  const response = await fetch(buildUrl(path, params));
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+};

--- a/frontend/src/components/DiscoveryCharts.tsx
+++ b/frontend/src/components/DiscoveryCharts.tsx
@@ -1,0 +1,82 @@
+import { Bar, Doughnut } from 'react-chartjs-2';
+import {
+  ArcElement,
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  Title,
+  Tooltip
+} from 'chart.js';
+import Skeleton from './Skeleton';
+import type { DiscoveryDataset } from '../types';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend);
+
+type Props = {
+  discovery?: DiscoveryDataset;
+  loading?: boolean;
+};
+
+const DiscoveryCharts = ({ discovery, loading }: Props) => {
+  if (loading) {
+    return <Skeleton height={400} />;
+  }
+
+  if (!discovery) {
+    return null;
+  }
+
+  const histogramData = {
+    labels: discovery.histogram.bins,
+    datasets: [
+      {
+        label: 'Planets per temperature bucket',
+        data: discovery.histogram.counts,
+        backgroundColor: '#9333ea'
+      }
+    ]
+  };
+
+  const methodData = {
+    labels: discovery.method_series.map((item) => item.method),
+    datasets: [
+      {
+        label: 'Discoveries',
+        data: discovery.method_series.map((item) => item.count),
+        backgroundColor: ['#1d4ed8', '#9333ea', '#14b8a6', '#f97316', '#6366f1', '#facc15']
+      }
+    ]
+  };
+
+  const yearData = {
+    labels: discovery.year_series.map((item) => item.year),
+    datasets: [
+      {
+        label: 'Discoveries',
+        data: discovery.year_series.map((item) => item.count),
+        backgroundColor: '#0ea5e9'
+      }
+    ]
+  };
+
+  return (
+    <div className="card-grid">
+      <div className="card">
+        <h3>Stellar Temperature Histogram</h3>
+        <Bar data={histogramData} options={{ maintainAspectRatio: false }} />
+      </div>
+      <div className="card">
+        <h3>Discoveries by Method</h3>
+        <Doughnut data={methodData} />
+      </div>
+      <div className="card" style={{ gridColumn: '1 / -1' }}>
+        <h3>Discoveries by Year</h3>
+        <Bar data={yearData} options={{ maintainAspectRatio: false }} />
+      </div>
+    </div>
+  );
+};
+
+export default DiscoveryCharts;

--- a/frontend/src/components/MetricCard.tsx
+++ b/frontend/src/components/MetricCard.tsx
@@ -1,0 +1,35 @@
+import Skeleton from './Skeleton';
+
+type Props = {
+  title: string;
+  metric: number;
+  unit?: string;
+  decimals?: number;
+  loading?: boolean;
+  description?: string;
+};
+
+const formatValue = (value: number, decimals = 1) =>
+  new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: decimals,
+    minimumFractionDigits: decimals
+  }).format(value);
+
+const MetricCard = ({ title, metric, unit = '', decimals = 1, loading, description }: Props) => {
+  return (
+    <article className="card">
+      <h2>{title}</h2>
+      {loading ? (
+        <Skeleton height={48} width={160} />
+      ) : (
+        <div className="metric">
+          {formatValue(metric, decimals)}
+          {unit}
+        </div>
+      )}
+      {description && <p className="metric-label">{description}</p>}
+    </article>
+  );
+};
+
+export default MetricCard;

--- a/frontend/src/components/PlanetFilters.tsx
+++ b/frontend/src/components/PlanetFilters.tsx
@@ -1,0 +1,79 @@
+import { ChangeEvent } from 'react';
+import { PlanetFilterState } from '../hooks/usePlanetFilters';
+
+const orderOptions = [
+  { value: 'name', label: 'Name' },
+  { value: 'discovery_year', label: 'Discovery Year' },
+  { value: 'orbital_period', label: 'Orbital Period' },
+  { value: 'radius', label: 'Radius' },
+  { value: 'mass', label: 'Mass' }
+];
+
+type Props = {
+  values: PlanetFilterState;
+  loading?: boolean;
+  onChange: (key: keyof PlanetFilterState, value: string) => void;
+  onReset: () => void;
+};
+
+const PlanetFilters = ({ values, loading, onChange, onReset }: Props) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = event.target;
+    onChange(name as keyof PlanetFilterState, value);
+  };
+
+  return (
+    <form className="filters" onSubmit={(event) => event.preventDefault()}>
+      <input
+        name="search"
+        placeholder="Search by planet name"
+        value={values.search}
+        onChange={handleChange}
+        disabled={loading}
+      />
+
+      <input
+        name="method"
+        placeholder="Discovery method"
+        value={values.method}
+        onChange={handleChange}
+        disabled={loading}
+      />
+
+      <input
+        name="minYear"
+        placeholder="Min year"
+        value={values.minYear}
+        onChange={handleChange}
+        disabled={loading}
+      />
+
+      <input
+        name="maxYear"
+        placeholder="Max year"
+        value={values.maxYear}
+        onChange={handleChange}
+        disabled={loading}
+      />
+
+      <select name="orderBy" value={values.orderBy} onChange={handleChange} disabled={loading}>
+        {orderOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            Order by {option.label}
+          </option>
+        ))}
+      </select>
+
+      <select name="orderDir" value={values.orderDir} onChange={handleChange} disabled={loading}>
+        <option value="asc">Ascending</option>
+        <option value="desc">Descending</option>
+      </select>
+
+      <button type="button" onClick={onReset} disabled={loading}>
+        Reset filters
+      </button>
+    </form>
+  );
+};
+
+export default PlanetFilters;

--- a/frontend/src/components/PlanetsTable.tsx
+++ b/frontend/src/components/PlanetsTable.tsx
@@ -1,0 +1,66 @@
+import Skeleton from './Skeleton';
+import type { PlanetListResponse } from '../types';
+
+type Props = {
+  response?: PlanetListResponse;
+  loading?: boolean;
+  onPageChange: (page: number) => void;
+};
+
+const PlanetsTable = ({ response, loading, onPageChange }: Props) => {
+  const planets = response?.results ?? [];
+  const total = response?.total ?? 0;
+  const page = response?.page ?? 1;
+  const pages = response?.pages ?? 1;
+
+  return (
+    <div className="table-container">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Discovery Method</th>
+            <th>Year</th>
+            <th>Orbital Period (days)</th>
+            <th>Radius (R⊕)</th>
+            <th>Mass (M⊕)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading
+            ? [...Array(6)].map((_, index) => (
+                <tr key={index}>
+                  <td colSpan={6}>
+                    <Skeleton height={20} />
+                  </td>
+                </tr>
+              ))
+            : planets.map((planet) => (
+                <tr key={planet.id}>
+                  <td>{planet.name}</td>
+                  <td>{planet.discovery_method}</td>
+                  <td>{planet.discovery_year ?? '—'}</td>
+                  <td>{planet.orbital_period?.toFixed(2) ?? '—'}</td>
+                  <td>{planet.radius?.toFixed(2) ?? '—'}</td>
+                  <td>{planet.mass?.toFixed(2) ?? '—'}</td>
+                </tr>
+              ))}
+        </tbody>
+      </table>
+
+      <footer className="pagination">
+        <div className="badge">{total} results</div>
+        <div>
+          <button onClick={() => onPageChange(page - 1)} disabled={page <= 1 || loading}>
+            Previous
+          </button>
+          <button onClick={() => onPageChange(page + 1)} disabled={page >= pages || loading}>
+            Next
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default PlanetsTable;

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,21 @@
+import { CSSProperties } from 'react';
+
+type Props = {
+  width?: number | string;
+  height?: number | string;
+};
+
+const Skeleton = ({ width = '100%', height = 16 }: Props) => {
+  const style: CSSProperties = {
+    width,
+    height,
+    borderRadius: '9999px',
+    background: 'linear-gradient(90deg, rgba(148, 163, 184, 0.2) 25%, rgba(148, 163, 184, 0.35) 37%, rgba(148, 163, 184, 0.2) 63%)',
+    backgroundSize: '400% 100%',
+    animation: 'pulse 1.4s ease infinite'
+  };
+
+  return <div style={style} />;
+};
+
+export default Skeleton;

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -1,0 +1,68 @@
+import { Line } from 'react-chartjs-2';
+import {
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Title,
+  Tooltip
+} from 'chart.js';
+import Skeleton from './Skeleton';
+import type { DiscoveryTimelinePoint } from '../types';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+
+type Props = {
+  series: DiscoveryTimelinePoint[];
+  loading?: boolean;
+};
+
+const TimelineChart = ({ series, loading }: Props) => {
+  if (loading) {
+    return <Skeleton height={280} />;
+  }
+
+  const data = {
+    labels: series.map((point) => point.year),
+    datasets: [
+      {
+        label: 'Discoveries',
+        data: series.map((point) => point.count),
+        fill: false,
+        borderColor: '#1d4ed8',
+        backgroundColor: '#1d4ed8',
+        tension: 0.3
+      }
+    ]
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      x: {
+        title: {
+          display: true,
+          text: 'Year'
+        }
+      },
+      y: {
+        beginAtZero: true,
+        title: {
+          display: true,
+          text: 'Number of discoveries'
+        }
+      }
+    }
+  };
+
+  return (
+    <div style={{ height: 320 }}>
+      <Line options={options} data={data} />
+    </div>
+  );
+};
+
+export default TimelineChart;

--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { get } from '../api/client';
+import type { DiscoveryStats, DiscoveryTimelinePoint } from '../types';
+
+export const useDiscoveryStats = () =>
+  useQuery({
+    queryKey: ['analytics', 'stats'],
+    queryFn: () => get<DiscoveryStats>('/planets/stats')
+  });
+
+export const useDiscoveryTimeline = () =>
+  useQuery({
+    queryKey: ['analytics', 'timeline'],
+    queryFn: () => get<DiscoveryTimelinePoint[]>('/planets/timeline')
+  });

--- a/frontend/src/hooks/useDiscoveryData.ts
+++ b/frontend/src/hooks/useDiscoveryData.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { get } from '../api/client';
+import type { DiscoveryDataset } from '../types';
+
+export const useDiscoveryData = () =>
+  useQuery({
+    queryKey: ['discovery', 'dataset'],
+    queryFn: () => get<DiscoveryDataset>('/vis/discovery', { chart: 'hist' })
+  });

--- a/frontend/src/hooks/usePlanetFilters.ts
+++ b/frontend/src/hooks/usePlanetFilters.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+export type PlanetFilterState = {
+  search: string;
+  method: string;
+  minYear: string;
+  maxYear: string;
+  orderBy: string;
+  orderDir: 'asc' | 'desc';
+};
+
+const defaultState: PlanetFilterState = {
+  search: '',
+  method: '',
+  minYear: '',
+  maxYear: '',
+  orderBy: 'discovery_year',
+  orderDir: 'desc'
+};
+
+export const usePlanetFilters = () => {
+  const [filters, setFilters] = useState<PlanetFilterState>(defaultState);
+
+  const updateFilter = (key: keyof PlanetFilterState, value: string) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const resetFilters = () => setFilters(defaultState);
+
+  return {
+    filters,
+    updateFilter,
+    resetFilters
+  };
+};

--- a/frontend/src/hooks/usePlanetList.ts
+++ b/frontend/src/hooks/usePlanetList.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { get } from '../api/client';
+import type { PlanetListResponse } from '../types';
+import type { PlanetFilterState } from './usePlanetFilters';
+
+const PAGE_SIZE = 20;
+
+type Params = PlanetFilterState;
+
+const mapFiltersToParams = (filters: Params, page: number) => ({
+  limit: PAGE_SIZE,
+  page,
+  name: filters.search,
+  method: filters.method,
+  min_year: filters.minYear,
+  max_year: filters.maxYear,
+  order_by: filters.orderBy,
+  order_dir: filters.orderDir
+});
+
+export const usePlanetList = (filters: Params) => {
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    setPage(1);
+  }, [filters]);
+
+  const query = useQuery({
+    queryKey: ['planets', { filters, page }],
+    queryFn: () => get<PlanetListResponse>('/planets', mapFiltersToParams(filters, page)),
+    keepPreviousData: true
+  });
+
+  return {
+    ...query,
+    setPage
+  };
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './pages/App';
+import './styles.css';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -1,0 +1,36 @@
+import { NavLink, Route, Routes } from 'react-router-dom';
+import DashboardPage from './DashboardPage';
+import PlanetsPage from './PlanetsPage';
+import VisualizationPage from './VisualizationPage';
+
+const App = () => {
+  return (
+    <main>
+      <header>
+        <div>
+          <h1>Exoplanet Explorer</h1>
+          <p>Discover planets beyond our solar system using the Exoplanet API.</p>
+        </div>
+        <nav>
+          <NavLink to="/" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`} end>
+            Dashboard
+          </NavLink>
+          <NavLink to="/planets" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
+            Catalog
+          </NavLink>
+          <NavLink to="/visualizations" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
+            Visualizations
+          </NavLink>
+        </nav>
+      </header>
+
+      <Routes>
+        <Route path="/" element={<DashboardPage />} />
+        <Route path="/planets" element={<PlanetsPage />} />
+        <Route path="/visualizations" element={<VisualizationPage />} />
+      </Routes>
+    </main>
+  );
+};
+
+export default App;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,53 @@
+import { useDiscoveryStats, useDiscoveryTimeline } from '../hooks/useAnalytics';
+import MetricCard from '../components/MetricCard';
+import TimelineChart from '../components/TimelineChart';
+
+const DashboardPage = () => {
+  const { data: stats, isLoading: statsLoading, error: statsError } = useDiscoveryStats();
+  const { data: timeline, isLoading: timelineLoading, error: timelineError } = useDiscoveryTimeline();
+
+  if (statsError || timelineError) {
+    return <div className="error">Unable to load dashboard metrics. Please try again later.</div>;
+  }
+
+  return (
+    <section className="card-grid">
+      <MetricCard
+        title="Catalogued Planets"
+        metric={stats?.planet_count ?? 0}
+        loading={statsLoading}
+        description="Total number of confirmed exoplanets in the database."
+      />
+      <MetricCard
+        title="Median Orbital Period"
+        metric={stats?.orbital_period?.median ?? 0}
+        unit=" days"
+        loading={statsLoading}
+        description="Half of all planets orbit their star in fewer days than this value."
+      />
+      <MetricCard
+        title="Median Planet Radius"
+        metric={stats?.radius?.median ?? 0}
+        unit=" R⊕"
+        loading={statsLoading}
+        description="The typical planet size relative to Earth."
+      />
+      <MetricCard
+        title="Average Stellar Temperature"
+        metric={stats?.stellar_temperature?.mean ?? 0}
+        unit=" K"
+        decimals={0}
+        loading={statsLoading}
+        description="Mean host-star temperature across the catalog."
+      />
+
+      <div className="card" style={{ gridColumn: '1 / -1' }}>
+        <h2>Discoveries per Year</h2>
+        <p>Track how exoplanet discoveries have accelerated over time.</p>
+        <TimelineChart loading={timelineLoading} series={timeline ?? []} />
+      </div>
+    </section>
+  );
+};
+
+export default DashboardPage;

--- a/frontend/src/pages/PlanetsPage.tsx
+++ b/frontend/src/pages/PlanetsPage.tsx
@@ -1,0 +1,30 @@
+import PlanetFilters from '../components/PlanetFilters';
+import PlanetsTable from '../components/PlanetsTable';
+import { usePlanetFilters } from '../hooks/usePlanetFilters';
+import { usePlanetList } from '../hooks/usePlanetList';
+
+const PlanetsPage = () => {
+  const { filters, updateFilter, resetFilters } = usePlanetFilters();
+  const { data, isLoading, error, setPage } = usePlanetList(filters);
+
+  return (
+    <section>
+      <PlanetFilters
+        values={filters}
+        onChange={updateFilter}
+        onReset={resetFilters}
+        loading={isLoading}
+      />
+
+      {error && <div className="error">Failed to load planets. Please adjust your filters.</div>}
+
+      <PlanetsTable
+        response={data}
+        loading={isLoading}
+        onPageChange={setPage}
+      />
+    </section>
+  );
+};
+
+export default PlanetsPage;

--- a/frontend/src/pages/VisualizationPage.tsx
+++ b/frontend/src/pages/VisualizationPage.tsx
@@ -1,0 +1,20 @@
+import DiscoveryCharts from '../components/DiscoveryCharts';
+import { useDiscoveryData } from '../hooks/useDiscoveryData';
+
+const VisualizationPage = () => {
+  const { data, isLoading, error } = useDiscoveryData();
+
+  if (error) {
+    return <div className="error">Unable to load visualization data. Please retry.</div>;
+  }
+
+  return (
+    <section className="card">
+      <h2>Discovery Visualizations</h2>
+      <p>Explore exoplanet discoveries by stellar temperature, detection method and year.</p>
+      <DiscoveryCharts loading={isLoading} discovery={data} />
+    </section>
+  );
+};
+
+export default VisualizationPage;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,171 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.08) 0%, rgba(248, 250, 252, 1) 70%);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  padding: 2.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.nav-link {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  transition: background-color 0.2s ease;
+}
+
+.nav-link.active {
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.card {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.table-container {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.table-container table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+ td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+th {
+  text-align: left;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.filters {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-bottom: 1.5rem;
+}
+
+input,
+ select {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  background-color: #f8fafc;
+}
+
+button {
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.75rem;
+  border: none;
+  background-color: #0f172a;
+  color: #f8fafc;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background-color: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.metric {
+  font-size: 2.2rem;
+  font-weight: 700;
+}
+
+.metric-label {
+  margin-top: 0.35rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.error {
+  color: #dc2626;
+  background-color: rgba(220, 38, 38, 0.08);
+  border: 1px solid rgba(220, 38, 38, 0.15);
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+}
+
+@keyframes pulse {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,47 @@
+export type PlanetSummary = {
+  id: number;
+  name: string;
+  discovery_method: string;
+  discovery_year: number | null;
+  orbital_period: number | null;
+  radius: number | null;
+  mass: number | null;
+};
+
+export type PlanetListResponse = {
+  results: PlanetSummary[];
+  page: number;
+  pages: number;
+  total: number;
+};
+
+export type MetricSummary = {
+  min: number | null;
+  max: number | null;
+  mean: number | null;
+  median: number | null;
+};
+
+export type DiscoveryStats = {
+  planet_count: number;
+  orbital_period: MetricSummary;
+  radius: MetricSummary;
+  mass: MetricSummary;
+  stellar_temperature: MetricSummary;
+};
+
+export type DiscoveryTimelinePoint = {
+  year: number;
+  count: number;
+};
+
+export type HistogramSeries = {
+  bins: number[];
+  counts: number[];
+};
+
+export type DiscoveryDataset = {
+  histogram: HistogramSeries;
+  year_series: DiscoveryTimelinePoint[];
+  method_series: { method: string; count: number }[];
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite-powered React client that consumes the existing FastAPI endpoints
- implement dashboard, catalog, and visualization pages backed by reusable hooks and components
- document development and build steps for deploying the new frontend

## Testing
- not run (frontend dependencies not installed in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_68ceb5de53d0832a9bc8d97a4167a498