### PR TITLE
Add median stats and secure PATCH endpoint

### DIFF
--- a/app/api/routes/planets.py
+++ b/app/api/routes/planets.py
@@ -326,21 +326,27 @@ def planet_statistics(db: Session = Depends(get_db)):
             func.min(Planet.orbperd).label("orbperd_min"),
             func.max(Planet.orbperd).label("orbperd_max"),
             func.avg(Planet.orbperd).label("orbperd_avg"),
+            func.percentile_cont(0.5).within_group(Planet.orbperd).label("orbperd_median"),
             func.min(Planet.rade).label("rade_min"),
             func.max(Planet.rade).label("rade_max"),
             func.avg(Planet.rade).label("rade_avg"),
+            func.percentile_cont(0.5).within_group(Planet.rade).label("rade_median"),
             func.min(Planet.masse).label("masse_min"),
             func.max(Planet.masse).label("masse_max"),
             func.avg(Planet.masse).label("masse_avg"),
+            func.percentile_cont(0.5).within_group(Planet.masse).label("masse_median"),
             func.min(Planet.st_teff).label("st_teff_min"),
             func.max(Planet.st_teff).label("st_teff_max"),
             func.avg(Planet.st_teff).label("st_teff_avg"),
+            func.percentile_cont(0.5).within_group(Planet.st_teff).label("st_teff_median"),
             func.min(Planet.st_rad).label("st_rad_min"),
             func.max(Planet.st_rad).label("st_rad_max"),
             func.avg(Planet.st_rad).label("st_rad_avg"),
+            func.percentile_cont(0.5).within_group(Planet.st_rad).label("st_rad_median"),
             func.min(Planet.st_mass).label("st_mass_min"),
             func.max(Planet.st_mass).label("st_mass_max"),
             func.avg(Planet.st_mass).label("st_mass_avg"),
+            func.percentile_cont(0.5).within_group(Planet.st_mass).label("st_mass_median"),
         )
         .where(Planet.is_deleted == False)
     )
@@ -352,6 +358,7 @@ def planet_statistics(db: Session = Depends(get_db)):
             "min": float(result[f"{prefix}_min"]) if result[f"{prefix}_min"] is not None else None,
             "max": float(result[f"{prefix}_max"]) if result[f"{prefix}_max"] is not None else None,
             "avg": float(result[f"{prefix}_avg"]) if result[f"{prefix}_avg"] is not None else None,
+            "median": float(result[f"{prefix}_median"]) if result.get(f"{prefix}_median") is not None else None,
         }
 
     return PlanetStats(
@@ -583,7 +590,8 @@ def list_deleted_planets(
     "/{planet_id}",
     response_model=PlanetOut,
     summary="Partially update a planet",
-    description="Updates only provided fields; others remain unchanged."
+    description="Updates only provided fields; others remain unchanged.",
+    dependencies=[Depends(api_key_auth)],
 )
 def update_planet_partial(planet_id: int, updates: PlanetUpdate, db: Session = Depends(get_db)):
     """

--- a/app/schemas/planet.py
+++ b/app/schemas/planet.py
@@ -165,11 +165,12 @@ class DeletedPlanetOut(BaseModel):
 
 
 class MetricSummary(BaseModel):
-    """Minimum, maximum and average summary for a numeric metric."""
+    """Minimum, maximum, average and median summary for a numeric metric."""
 
     min: Optional[float] = Field(None, description="Minimum value or null when unavailable")
     max: Optional[float] = Field(None, description="Maximum value or null when unavailable")
     avg: Optional[float] = Field(None, description="Average value or null when unavailable")
+    median: Optional[float] = Field(None, description="Median value or null when unavailable")
 
 
 class PlanetStats(BaseModel):


### PR DESCRIPTION
## Summary
- include median calculations in the global planet statistics response
- expose the new median field via the MetricSummary schema
- require API key authentication for partial planet updates

## Testing
- DATABASE_URL=sqlite:///./test.db API_KEY=test pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6ff260c7c832a8e762029fc130066