### PR TITLE
Record create and update timestamps for planets

### DIFF
--- a/app/api/routes/planets.py
+++ b/app/api/routes/planets.py
@@ -69,7 +69,11 @@ def create_planet(
         raise HTTPException(status_code=409, detail=f"Planet '{payload.name}' already exists.")
 
 
+    now = datetime.now(timezone.utc)
+
     planet = Planet(**payload.model_dump())
+    planet.created_at = now
+    planet.updated_at = now
     db.add(planet)
 
     try:
@@ -622,6 +626,8 @@ def update_planet_partial(planet_id: int, updates: PlanetUpdate, db: Session = D
 
     for k, v in data.items():
         setattr(planet, k, v)
+
+    planet.updated_at = datetime.now(timezone.utc)
 
     try:
         db.commit()

--- a/app/schemas/planet.py
+++ b/app/schemas/planet.py
@@ -88,6 +88,8 @@ class PlanetOut(PlanetBase):
     """
 
     id: int
+    created_at: datetime
+    updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
## Summary
- ensure planets created through the API capture their creation and update timestamps
- refresh the update route to bump the updated_at timestamp on every edit
- expose timestamp fields in the planet response schema

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d710baac8c832aa035c9a96dc52406