### PR TITLE
Remove API key dependency from change log endpoint

### DIFF
--- a/app/api/routes/planets.py
+++ b/app/api/routes/planets.py
@@ -528,7 +528,6 @@ def method_statistics(disc_method: str, db: Session = Depends(get_db)):
     response_model=list[PlanetChangeLogEntry],
     summary="List planet change logs",
     description="Returns the most recent change log entries for planet mutations.",
-    dependencies=[Depends(api_key_auth)],
 )
 def list_planet_change_logs(
     db: Session = Depends(get_db),


### PR DESCRIPTION
## Summary
- remove the API key authentication dependency from the planets change-log endpoint so it is publicly accessible

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d83fc9fbe4832abb7bcafd6bfaf449